### PR TITLE
Make the select functionality configurable so users can turn it off if needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ first input of your form/page).
 
     {{focus-input value=model.field class="foo"}}
 
+By default the input will be focused and have the content selected. If you prefer not to have the text selected/highlighted configure it like so.
+
+    {{focus-input value=model.field class="foo" select="false"}}
+
 ## Focus Button
 
     {{focus-button value=model.buttonField class="bar"}}

--- a/addon/components/focus-input.js
+++ b/addon/components/focus-input.js
@@ -1,9 +1,13 @@
 import Ember from 'ember';
 
 var FocusInput = Ember.TextField.extend({
+    attributeBindings: ["select"],
     didInsertElement: function() {
         this.$().focus();
-        this.$().select();
+        var select = this.get("select");
+        if(select !== "false") {
+            this.$().select();
+        }
     }
 });
 

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,6 @@
   "dependencies": {
     "jquery": "^1.11.1",
     "ember": "1.10.0",
-    "ember-data": "1.0.0-beta.15",
     "ember-resolver": "~0.1.12",
     "loader.js": "ember-cli/loader.js#3.2.0",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-focus-input",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Components that have focus",
   "directories": {
     "doc": "doc",

--- a/tests/acceptance/focus-test.js
+++ b/tests/acceptance/focus-test.js
@@ -6,6 +6,7 @@ import {isFocused} from 'ember-cli-test-helpers/tests/helpers/input';
 var application, originalSelect;
 
 var FOCUSED_INPUT = 'input.focused-input';
+var UNSELECTED_INPUT = 'input.focused-input-not-selected';
 var FOCUSED_BUTTON = 'button.focused-button';
 
 module('Acceptance: Focus', {
@@ -46,5 +47,31 @@ test('First button should have focus', function(assert) {
         assert.equal(currentURL(), '/button');
         isFocused(FOCUSED_BUTTON);
         assert.equal(find(FOCUSED_BUTTON).attr('type'), 'submit');
+    });
+});
+
+test('focused field can be configured to not select the value on focus', function(assert) {
+    var selected = false;
+    $.prototype.select = function() {
+        selected = true;
+    };
+    visit('/unselected');
+    andThen(function() {
+        assert.equal(currentURL(), '/unselected');
+        assert.equal(find(UNSELECTED_INPUT).val(), 'foo');
+        assert.equal(selected, false);
+    });
+});
+
+test('focused field will have any className attribute set in the template', function(assert) {
+    visit('/unselected');
+    andThen(function() {
+        assert.equal(currentURL(), '/unselected');
+        assert.ok(find(UNSELECTED_INPUT).hasClass('watwat'));
+    });
+    visit('/input');
+    andThen(function() {
+        assert.equal(currentURL(), '/input');
+        assert.ok(find(FOCUSED_INPUT).hasClass('yoyo'));
     });
 });

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -7,6 +7,7 @@ var Router = Ember.Router.extend({
 
 Router.map(function() {
     this.route("input", {path: "/input"});
+    this.route("unselected", {path: "/unselected"});
     this.route("button", {path: "/button"});
 });
 

--- a/tests/dummy/app/routes/unselected.js
+++ b/tests/dummy/app/routes/unselected.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+    model: function() {
+        return Ember.Object.create({name: 'foo'});
+    }
+});

--- a/tests/dummy/app/templates/input.hbs
+++ b/tests/dummy/app/templates/input.hbs
@@ -1,3 +1,3 @@
-{{focus-input value=model.name class="focused-input"}}
+{{focus-input value=model.name class="focused-input yoyo"}}
 
 {{input class="unfocused-input"}}

--- a/tests/dummy/app/templates/unselected.hbs
+++ b/tests/dummy/app/templates/unselected.hbs
@@ -1,0 +1,1 @@
+{{focus-input value=model.name class="focused-input-not-selected watwat" select="false"}}


### PR DESCRIPTION
This includes the ability to turn off the select when needed (the default is still to select but this enhancement is a nice to have for UX that doesn't require the highlight/select func).

After I created this PR I realized I forgot to put something in the README about it - I'll see if I can add to this tonight and force push up the changes :)