### PR TITLE
Remove instruction to run generator. Fixes #4.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ first input of your form/page).
 
     # Install via npm
     $ npm install ember-cli-focus-input --save-dev
-    # make ember-cli fetch interal dependencies
-    $ ember g ember-cli-focus-input
 
 ## Focus Input
 


### PR DESCRIPTION
I got tripped up because the README said to run the generator. All I really needed to do was install the addon and restart my dev server.